### PR TITLE
Change "when stream" message

### DIFF
--- a/events/on_message.py
+++ b/events/on_message.py
@@ -36,7 +36,7 @@ class Message(commands.Cog):
             await message.add_reaction("✈️")
         elif msg_list[3] in lower_content:
             await message.reply(
-                "The stream will start at <t:1721689200:t> (local time), unless said otherwise by streamer or the host.")
+                "A confirmed date and time of the stream will be announced by the current host or the streamer after the deadline in <#657107735720230922>")
 
 
     async def wait_crazy(self, message):


### PR DESCRIPTION
Quoting Kierio:
> there should not be such a thing as a regular stream time when the streamer can change from task to task
> even still, that message is now 2 hours off of what dash thinks regular stream time is thanks to daylight savings