### PR TITLE
Fix display name mentions and embeds

### DIFF
--- a/api/submissions.py
+++ b/api/submissions.py
@@ -135,11 +135,13 @@ async def post_submission_list(channel, id, name):
         mentions = ' '.join([f'<@{user_id}>' for user_id in ids])
 
         return await channel.send(
-            f"**__Current Submissions:__**\n1. {team_name} ({' & '.join(members)}) ||{mentions}||")
+            f"**__Current Submissions:__**\n1. {team_name} ({' & '.join(members)}) ||{mentions}||",
+            allowed_mentions=discord.AllowedMentions.none(), suppress_embeds=True)
 
     # Case if solo
     return await channel.send(
-        f"**__Current Submissions:__**\n1. {name} ||<@{id}>||")
+        f"**__Current Submissions:__**\n1. {name} ||<@{id}>||",
+        allowed_mentions=discord.AllowedMentions.none(), suppress_embeds=True)
 
 
 async def update_submission_list(last_message, id, name):
@@ -288,7 +290,8 @@ async def handle_dms(message, self):
         attachments = message.attachments
         if channel:
             await channel.send(f"Message from {author_dn}: {message.content} " +
-                                " ".join([attachment.url for attachment in message.attachments if message.attachments]))
+                                " ".join([attachment.url for attachment in message.attachments if message.attachments]),
+                                allowed_mentions=discord.AllowedMentions.none(), suppress_embeds=True)
 
         #########################
         # Recognizing submission

--- a/commands/db/admin/setname.py
+++ b/commands/db/admin/setname.py
@@ -50,7 +50,8 @@ class Setname(commands.Cog):
         # Update submission list
         await generate_submission_list(self)
 
-        await ctx.send(f"Sucessfully set <@{user_id}>'s name to **{new_name}**.")
+        await ctx.send(f"Sucessfully set <@{user_id}>'s name to **{new_name}**.",
+            allowed_mentions=discord.AllowedMentions.none(), suppress_embeds=True)
 
 
 async def setup(bot) -> None:

--- a/commands/db/host/deletesubmission.py
+++ b/commands/db/host/deletesubmission.py
@@ -56,7 +56,8 @@ class DeleteSubmission(commands.Cog):
         await generate_submission_list(self)
 
 
-        await ctx.send(f"{user.display_name}'s submission has been deleted.")
+        await ctx.send(f"{user.display_name}'s submission has been deleted.",
+            allowed_mentions=discord.AllowedMentions.none(), suppress_embeds=True)
 
 
 async def setup(bot) -> None:

--- a/commands/db/host/edit-submissions.py
+++ b/commands/db/host/edit-submissions.py
@@ -16,7 +16,8 @@ class Edit(commands.Cog):
             data = (await session.scalars(select(Submissions).where(Submissions.user_id == user.id))).first()
 
         if data is None:
-            return await ctx.reply(f"{user} has no submission.")
+            return await ctx.reply(f"{user} has no submission.",
+                allowed_mentions=discord.AllowedMentions.none(), suppress_embeds=True)
         data_dq = None
         # was DQ or not
         if data.dq == 0:
@@ -38,9 +39,11 @@ class Edit(commands.Cog):
                 update(Submissions).values(time=time, dq=dq, dq_reason=dq_reason).where(Submissions.user_id == user.id))
             await session.commit()
 
-        await ctx.reply(server_text)
+        await ctx.reply(server_text,
+            allowed_mentions=discord.AllowedMentions.none(), suppress_embeds=True)
         channel = await user.create_dm()
-        await channel.send(dm_text)
+        await channel.send(dm_text,
+            allowed_mentions=discord.AllowedMentions.none(), suppress_embeds=True)
 
 
 

--- a/commands/db/host/get-submissions.py
+++ b/commands/db/host/get-submissions.py
@@ -1,3 +1,4 @@
+from discord import AllowedMentions
 from discord.ext import commands
 from api.submissions import get_display_name, get_team_ids, get_team_members, get_team_name
 from api.utils import has_host_role, float_to_readable, is_in_team
@@ -64,12 +65,16 @@ class Get(commands.Cog):
             for i, part in enumerate(submissions_parts):
                 if i == 0:
                     if len(header + part) > msg_limit:
-                        await ctx.reply(header)
-                        await ctx.reply(part)
+                        await ctx.reply(header,
+                            allowed_mentions=AllowedMentions.none(), suppress_embeds=True)
+                        await ctx.reply(part,
+                            allowed_mentions=AllowedMentions.none(), suppress_embeds=True)
                     else:
-                        await ctx.reply(header + part)
+                        await ctx.reply(header + part,
+                            allowed_mentions=AllowedMentions.none(), suppress_embeds=True)
                 else:
-                    await ctx.reply(part)
+                    await ctx.reply(part,
+                        allowed_mentions=AllowedMentions.none(), suppress_embeds=True)
 
                 await asyncio.sleep(1)
 

--- a/commands/db/team/collab.py
+++ b/commands/db/team/collab.py
@@ -100,7 +100,8 @@ class Collab(commands.Cog):
         # Check if invited person is already in a team
         for user in users:
             if await is_in_team(user.id):
-                return await ctx.send(f"{user.display_name} is already in a team and cannot join another.")
+                return await ctx.send(f"{user.display_name} is already in a team and cannot join another.",
+                    allowed_mentions=discord.AllowedMentions.none(), suppress_embeds=True)
 
         # Check if the author is already in a team
         current_team = await self.get_current_team(author_id)
@@ -139,7 +140,7 @@ class Collab(commands.Cog):
             )
             message = await ctx.send(
                 f"{user.mention}, {ctx.author.display_name} wants you to collaborate with them. Do you accept?",
-                view=view
+                view=view, allowed_mentions=discord.AllowedMentions.none(), suppress_embeds=True
             )
             view.message = message  # Store the message in the view for later editing
 

--- a/commands/fun/addcoins.py
+++ b/commands/fun/addcoins.py
@@ -13,7 +13,8 @@ class Addcoins(commands.Cog):
     async def addcoins(self, ctx, user: discord.Member, amount: int):
         user_id = user.id
         await add_balance(user_id, ctx.guild.id, amount)
-        await ctx.reply(f"Added {amount} coins to {user.display_name}'s balance.")
+        await ctx.reply(f"Added {amount} coins to {user.display_name}'s balance.",
+            allowed_mentions=discord.AllowedMentions.none(), suppress_embeds=True)
 
 
 async def setup(bot) -> None:

--- a/commands/fun/balance.py
+++ b/commands/fun/balance.py
@@ -13,7 +13,8 @@ class Balance(commands.Cog):
             # TODO: probably search by ID
             user_handle = user.id
             balance = await get_balance(user_handle, ctx.message.guild.id)
-            await ctx.reply(f"{user.display_name} current balance is {balance} coins.")
+            await ctx.reply(f"{user.display_name} current balance is {balance} coins.",
+                allowed_mentions=discord.AllowedMentions.none(), suppress_embeds=True)
         else:
             user_id = ctx.author.id
             balance = await get_balance(user_id, ctx.message.guild.id)

--- a/commands/fun/balancetop.py
+++ b/commands/fun/balancetop.py
@@ -1,3 +1,4 @@
+from discord import AllowedMentions
 from discord.ext import commands
 from api.db_classes import Money, get_session
 from sqlalchemy import select
@@ -24,7 +25,8 @@ class Balancetop(commands.Cog):
                 name = f"User with ID {result[i].user_id} (left the server)"
             leaderboard += f"{i + 1}: {name} - {result[i].coins}\n"
 
-        await ctx.send(leaderboard)
+        await ctx.send(leaderboard,
+            allowed_mentions=AllowedMentions.none(), suppress_embeds=True)
 
 
 async def setup(bot) -> None:


### PR DESCRIPTION
Adds `allowed_mentions=discord.AllowedMentions.none(), suppress_embeds=True` to every `send` and `reply` call that uses a user's display name.